### PR TITLE
Add a parent POM to better mirror the Maven project structure.

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -2,6 +2,13 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>monopoly</artifactId>
+		<groupId>io.github.ser215_team11</groupId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+
 	<groupId>io.github.ser215_team11.monopoly</groupId>
 	<artifactId>client</artifactId>
 	<packaging>jar</packaging>
@@ -12,41 +19,20 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
-	<build>
-		<plugins>
-			<!-- The compiler plugin comes pre-installed, but we need to specify that we're using Java 8 -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
-		        <configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-		        </configuration>
-		    </plugin>
-		</plugins>
-	</build>
-
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>3.8.1</version>
-			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.luaj</groupId>
 			<artifactId>luaj-jse</artifactId>
-			<version>3.0.1</version>
-			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20150729</version>
-			<scope>compile</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>io.github.ser215_team11</groupId>
+	<artifactId>monopoly</artifactId>
+	<packaging>pom</packaging>
+	<version>1.0-SNAPSHOT</version>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<!-- The compiler plugin comes pre-installed, but we need to specify that we're using Java 8 -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+		        <configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+		        </configuration>
+		    </plugin>
+		</plugins>
+	</build>
+
+	<modules>
+		<module>client</module>
+	</modules>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>junit</groupId>
+				<artifactId>junit</artifactId>
+				<version>3.8.1</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.luaj</groupId>
+				<artifactId>luaj-jse</artifactId>
+				<version>3.0.1</version>
+				<scope>compile</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.json</groupId>
+				<artifactId>json</artifactId>
+				<version>20150729</version>
+				<scope>compile</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+</project>


### PR DESCRIPTION
From the beginning, "client" was intended to be a single module in the whole project, even if we only ever have the client module. This doesn't mean much, though, if there isn't a parent POM to manage the module(s). This PR adds a parent POM and solidifies the client's roll as a module. The actual benefits are:

1. Shared plugins are defined all in one place.
2. Dependency versions are defined all in one place.
3. Maven tools are more likely to work well with our project, specifically Travis CI.
