### PR TITLE
Add card scripts that only depend on the player

### DIFF
--- a/client/src/main/java/io/github/ser215_team11/monopoly/client/Player.java
+++ b/client/src/main/java/io/github/ser215_team11/monopoly/client/Player.java
@@ -12,7 +12,7 @@ public class Player {
 	int turns_left_in_jail;
 	boolean still_in_game;
 	Property the_array[];
-	
+
 	public Player()//default constructor
 	{
 		pos_of_player=0;
@@ -20,10 +20,10 @@ public class Player {
 		getOutOfJail = 0;
 		turns_left_in_jail=0;
 		still_in_game = true;
-		
+
 		Property[] the_array = new Property[0];
 	}
-	
+
 // setter and getter for token type
 	public void set_tokenType(int token)
 		{
@@ -33,7 +33,7 @@ public class Player {
 		{
 			return token_type;
 		}
-	
+
 	// setter and getter for name
 	public void set_name(String playerName)
 		{
@@ -43,7 +43,7 @@ public class Player {
 		{
 			return name;
 		}
-	
+
 	// setter and getter for pos_of_player
 	public void set_pos_of_player(int player_pos)
 		{
@@ -53,27 +53,61 @@ public class Player {
 		{
 			return pos_of_player;
 		}
-	
-	// Setter and getter for money
-	public void set_money(int amount)
-		{
-			money = amount;
-		}
-	public int get_money()
-		{
-			return money;
-		}
-	
+
+	/**
+	 * Sets the player's money to the given value.
+	 *
+	 * @param amount money in dollars
+	 */
+	public void set_money(int amount) {
+		money = amount;
+	}
+
+	/**
+	 * Adds the given amount to the player's total money.
+	 *
+	 * @param amount money in dollars
+	 */
+	public void giveMoney(int amount) {
+		money += amount;
+	}
+
+	/**
+	 * Subtracts the given amount to the player's total money.
+	 *
+	 * @param amount money in dollars
+	 */
+	public void takeMoney(int amount) {
+		money -= amount;
+	}
+
+	/**
+	 * Returns the user's current money in dollars.
+	 *
+	 * @return player's current money in dollars
+	 */
+	public int get_money() {
+		return money;
+	}
+
 	// setter and getter for getOutOfJail
-	public void set_getOutOfJail(int get_out)
+	public void set_getOutOfJailFree(int get_out)
 		{
 			getOutOfJail = get_out;
 		}
-	public int get_getOutOfJail()
+
+	/**
+	 * Gives the player one Get Out of Jail Free card.
+	 */
+	public void giveGetOutOfJailFreeCard() {
+		getOutOfJail++;
+	}
+
+	public int get_getOutOfJailFree()
 		{
 			return getOutOfJail;
 		}
-	
+
 	// setter and getter for turns left in jail
 	public void set_turns_left_in_jail(int jail_turn_left)
 		{
@@ -94,4 +128,3 @@ public class Player {
 			return still_in_game;
 		}
 }
-

--- a/client/src/main/java/io/github/ser215_team11/monopoly/client/PlayerLuaLibrary.java
+++ b/client/src/main/java/io/github/ser215_team11/monopoly/client/PlayerLuaLibrary.java
@@ -56,33 +56,112 @@ public class PlayerLuaLibrary extends TwoArgFunction {
 		LuaValue library = tableOf();
 
 		// Make functions available to Lua
-		library.set("test", new TestFunction());
+		library.set("giveMoney", new GiveMoneyFunction());
+		library.set("takeMoney", new TakeMoneyFunction());
+		library.set("giveGetOutOfJailFreeCard", new GiveGetOutOfJailFreeCardFunction());
+		library.set("sendToJail", new SendToJailFunction());
+		library.set("getHouseCnt", new GetHouseCntFunction());
+		library.set("getHotelCnt", new GetHotelCntFunction());
 
 		return library;
 	}
 
 	/**
-	 * Implements a test function that does nothing. This is used to check if
-	 * Lua is able to call functions correctly. This may be removable after the
-	 * player class is implemented.
+	 * Implements a function that gives the player money.
 	 */
-	static class TestFunction extends ZeroArgFunction {
-		/**
-		 * An empty constructor. If this isn't here, Luaj won't find this library.
-		 */
-		public TestFunction() {
+	static class GiveMoneyFunction extends OneArgFunction {
+		public GiveMoneyFunction() {
 		}
 
-		/**
-		 * This method is called when the test function is called. This does
-		 * nothing. We should never need to call this method.
-		 *
-		 * @return nil
-		 */
+		@Override
+		public LuaValue call(LuaValue amount) {
+			synchronized(target) {
+				int amountInt = amount.checkint();
+				target.giveMoney(amountInt);
+
+				return LuaValue.NIL;
+			}
+		}
+	}
+
+	/**
+	 * Implements a function that takes money from the player.
+	 */
+	static class TakeMoneyFunction extends OneArgFunction {
+		public TakeMoneyFunction() {
+		}
+
+		@Override
+		public LuaValue call(LuaValue amount) {
+			synchronized(target) {
+				int amountInt = amount.checkint();
+				target.takeMoney(amountInt);
+
+				return LuaValue.NIL;
+			}
+		}
+	}
+
+	/**
+	 * Implements a function that gives the player a Get Out of Jail Free card.
+	 */
+	static class GiveGetOutOfJailFreeCardFunction extends ZeroArgFunction {
+		public GiveGetOutOfJailFreeCardFunction() {
+		}
+
 		@Override
 		public LuaValue call() {
 			synchronized(target) {
+				target.giveGetOutOfJailFreeCard();
 				return LuaValue.NIL;
+			}
+		}
+	}
+
+	/**
+	 * Implements a function that sends the player to jail.
+	 */
+	static class SendToJailFunction extends ZeroArgFunction {
+		public SendToJailFunction() {
+		}
+
+		@Override
+		public LuaValue call() {
+			synchronized(target) {
+				target.set_turns_left_in_jail(3);
+				return LuaValue.NIL;
+			}
+		}
+	}
+
+	/**
+	 * Implements a function that returns the player's total house count.
+	 */
+	static class GetHouseCntFunction extends ZeroArgFunction {
+		public GetHouseCntFunction() {
+		}
+
+		@Override
+		public LuaValue call() {
+			synchronized(target) {
+				// TODO: Count the player's total houses when the properties class is implemented
+				return LuaValue.valueOf(3);
+			}
+		}
+	}
+
+	/**
+	 * Implements a function that returns the player's total hotel count.
+	 */
+	static class GetHotelCntFunction extends ZeroArgFunction {
+		public GetHotelCntFunction() {
+		}
+
+		@Override
+		public LuaValue call() {
+			synchronized(target) {
+				// TODO: Count the player's total hotels when the properties class is implemented
+				return LuaValue.valueOf(5);
 			}
 		}
 	}

--- a/client/src/main/java/io/github/ser215_team11/monopoly/client/Resources.java
+++ b/client/src/main/java/io/github/ser215_team11/monopoly/client/Resources.java
@@ -1,0 +1,21 @@
+package io.github.ser215_team11.monopoly.client;
+
+/**
+ * Contains static methods for dealing with resources.
+ */
+public class Resources {
+
+    /**
+     * Returns the corresponding resource path for a given regular path. If you
+     * want to access a file called "myFile.txt" inside the resources directory,
+     * you can pass "/myFile.txt" into this method and get the actual path to
+     * the resource.
+     *
+     * @param regPath path to the file relative to the resources directory
+     * @return path to the actual resource
+     */
+    public static String path(String regPath) {
+        return Resources.class.getResource(regPath).getPath();
+    }
+
+}

--- a/client/src/main/resources/config/community-chest.json
+++ b/client/src/main/resources/config/community-chest.json
@@ -30,7 +30,7 @@
 		},
 		{
 			"description": "Holiday Fund matures\\nRecieve $100",
-			"script": "/scripts/doctors-fee.lua"
+			"script": "/scripts/holiday-fund.lua"
 		},
 		{
 			"description": "Income tax refund\\nCollect $20",

--- a/client/src/main/resources/scripts/bank-dividend.lua
+++ b/client/src/main/resources/scripts/bank-dividend.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.giveMoney(50)

--- a/client/src/main/resources/scripts/bank-error.lua
+++ b/client/src/main/resources/scripts/bank-error.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.giveMoney(200)

--- a/client/src/main/resources/scripts/beauty-contest.lua
+++ b/client/src/main/resources/scripts/beauty-contest.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.giveMoney(10)

--- a/client/src/main/resources/scripts/building-loan.lua
+++ b/client/src/main/resources/scripts/building-loan.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.giveMoney(150)

--- a/client/src/main/resources/scripts/consultancy-fee.lua
+++ b/client/src/main/resources/scripts/consultancy-fee.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.giveMoney(25)

--- a/client/src/main/resources/scripts/crossword.lua
+++ b/client/src/main/resources/scripts/crossword.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.giveMoney(100)

--- a/client/src/main/resources/scripts/doctors-fee.lua
+++ b/client/src/main/resources/scripts/doctors-fee.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.takeMoney(50)

--- a/client/src/main/resources/scripts/general-repairs.lua
+++ b/client/src/main/resources/scripts/general-repairs.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.takeMoney(player.getHouseCnt() * 25 + player.getHotelCnt() * 100)

--- a/client/src/main/resources/scripts/go-to-jail.lua
+++ b/client/src/main/resources/scripts/go-to-jail.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.sendToJail()

--- a/client/src/main/resources/scripts/holiday-fund.lua
+++ b/client/src/main/resources/scripts/holiday-fund.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.giveMoney("100")

--- a/client/src/main/resources/scripts/hospital-fees.lua
+++ b/client/src/main/resources/scripts/hospital-fees.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.takeMoney(100)

--- a/client/src/main/resources/scripts/income-tax-refund.lua
+++ b/client/src/main/resources/scripts/income-tax-refund.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.giveMoney(20)

--- a/client/src/main/resources/scripts/inherit.lua
+++ b/client/src/main/resources/scripts/inherit.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.giveMoney(100)

--- a/client/src/main/resources/scripts/jail-free.lua
+++ b/client/src/main/resources/scripts/jail-free.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.giveGetOutOfJailFreeCard();

--- a/client/src/main/resources/scripts/life-insurance.lua
+++ b/client/src/main/resources/scripts/life-insurance.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.giveMoney(100)

--- a/client/src/main/resources/scripts/poor-tax.lua
+++ b/client/src/main/resources/scripts/poor-tax.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.takeMoney(15)

--- a/client/src/main/resources/scripts/school-fees.lua
+++ b/client/src/main/resources/scripts/school-fees.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.takeMoney(150)

--- a/client/src/main/resources/scripts/stock.lua
+++ b/client/src/main/resources/scripts/stock.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.takeMoney(50)

--- a/client/src/main/resources/scripts/street-repairs.lua
+++ b/client/src/main/resources/scripts/street-repairs.lua
@@ -1,0 +1,3 @@
+local player = require("io.github.ser215_team11.monopoly.client.PlayerLuaLibrary")
+
+player.takeMoney(player.getHouseCnt() * 40 + player.getHotelCnt() * 115)

--- a/client/src/test/java/io/github/ser215_team11/monopoly/client/TestCardSpace.java
+++ b/client/src/test/java/io/github/ser215_team11/monopoly/client/TestCardSpace.java
@@ -30,7 +30,7 @@ public class TestCardSpace extends TestCase {
 		// Use a hash map to keep track of drawn cards
 		Map<Card, Integer> drawnCards = new HashMap<>();
 
-		CardSpace cardSpace = new CardSpace("Community Chest", this.getClass().getResource("/config/test-cards.json").getPath());
+		CardSpace cardSpace = new CardSpace("Community Chest", Resources.path("/config/test-cards.json"));
 		// Check that all the cards were loaded
 		Assert.assertEquals("fewer cards were loaded than expected", cardSpace.getCardCnt(), 10);
 		// Draw all the cards

--- a/client/src/test/java/io/github/ser215_team11/monopoly/client/TestPlayerLuaLibrary.java
+++ b/client/src/test/java/io/github/ser215_team11/monopoly/client/TestPlayerLuaLibrary.java
@@ -34,14 +34,101 @@ public class TestPlayerLuaLibrary extends TestCase {
 	}
 
 	/**
-	 * Tests that player library functions can be called.
+	 * Tests the give money function.
 	 */
-	public void testCanCallFunctions() {
-		PlayerLuaLibrary.setTarget(new Player());
+	public void testGiveMoneyFunction() {
+		Player player = new Player();
+		int startMoney = player.get_money();
+		PlayerLuaLibrary.setTarget(player);
+
 		Globals globals = JsePlatform.standardGlobals();
 		LuaValue chunk = globals.load(
 			"local player = require 'io.github.ser215_team11.monopoly.client.PlayerLuaLibrary'\n" +
-			"player.test()");
+			"player.giveMoney(500)");
+
+		chunk.call();
+		Assert.assertEquals(player.get_money(), startMoney + 500);
+	}
+
+	/**
+	 * Tests the take money function.
+	 */
+	public void testTakeMoneyFunction() {
+		Player player = new Player();
+		int startMoney = player.get_money();
+		PlayerLuaLibrary.setTarget(player);
+
+		Globals globals = JsePlatform.standardGlobals();
+		LuaValue chunk = globals.load(
+			"local player = require 'io.github.ser215_team11.monopoly.client.PlayerLuaLibrary'\n" +
+			"player.takeMoney(500)");
+
+		chunk.call();
+		Assert.assertEquals(player.get_money(), startMoney - 500);
+	}
+
+	/**
+	 * Tests the give Get Out of Jail Free card function.
+	 */
+	public void testGiveGetOutOfJailFreeCardFunction() {
+		Player player = new Player();
+		int startCardCnt = player.get_getOutOfJailFree();
+		PlayerLuaLibrary.setTarget(player);
+
+		Globals globals = JsePlatform.standardGlobals();
+		LuaValue chunk = globals.load(
+			"local player = require 'io.github.ser215_team11.monopoly.client.PlayerLuaLibrary'\n" +
+			"player.giveGetOutOfJailFreeCard()");
+
+		chunk.call();
+		Assert.assertEquals(player.get_getOutOfJailFree(), startCardCnt + 1);
+	}
+
+	/**
+	 * Tests the send to jail function.
+	 */
+	public void testSendToJailFunction() {
+		Player player = new Player();
+		int startJail = player.get_turns_left_in_jail();
+		Assert.assertEquals(startJail, 0);
+		PlayerLuaLibrary.setTarget(player);
+
+		Globals globals = JsePlatform.standardGlobals();
+		LuaValue chunk = globals.load(
+			"local player = require 'io.github.ser215_team11.monopoly.client.PlayerLuaLibrary'\n" +
+			"player.sendToJail()");
+
+		chunk.call();
+		Assert.assertEquals(player.get_turns_left_in_jail(), 3);
+	}
+
+	/**
+	 * Tests the get house count function.
+	 */
+	public void testGetHouseCntFunction() {
+		Player player = new Player();
+		PlayerLuaLibrary.setTarget(player);
+
+		Globals globals = JsePlatform.standardGlobals();
+		LuaValue chunk = globals.load(
+			"local player = require 'io.github.ser215_team11.monopoly.client.PlayerLuaLibrary'\n" +
+			"player.getHouseCnt()");
+
+		chunk.call();
+	}
+
+	/**
+	 * Tests the get hotel count function.
+	 */
+	public void testGetHotelCntFunction() {
+		Player player = new Player();
+		PlayerLuaLibrary.setTarget(player);
+
+		Globals globals = JsePlatform.standardGlobals();
+		LuaValue chunk = globals.load(
+			"local player = require 'io.github.ser215_team11.monopoly.client.PlayerLuaLibrary'\n" +
+			"player.getHotelCnt()");
+
 		chunk.call();
 	}
 
@@ -61,4 +148,5 @@ public class TestPlayerLuaLibrary extends TestCase {
 		} catch(LuaError e) {
 		}
 	}
+
 }

--- a/client/src/test/java/io/github/ser215_team11/monopoly/client/TestScriptsRun.java
+++ b/client/src/test/java/io/github/ser215_team11/monopoly/client/TestScriptsRun.java
@@ -1,0 +1,60 @@
+package io.github.ser215_team11.monopoly.client;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import junit.framework.Assert;
+
+import org.luaj.vm2.Globals;
+import org.luaj.vm2.LuaValue;
+import org.luaj.vm2.lib.jse.JsePlatform;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Tests that all scripts in the /resources/scripts directory can be run without
+ * error.
+ */
+public class TestScriptsRun extends TestCase {
+
+	public TestScriptsRun(String testName) {
+		super(testName);
+	}
+
+	public static Test suite() {
+        return new TestSuite(TestScriptsRun.class);
+    }
+
+	/**
+	 * Tests scripts for syntax errors by running them.
+	 */
+	public void testScriptsRun() throws IOException {
+		// Loop through every script in the scripts directory
+		Files.walk(Paths.get(Resources.path("/scripts/"))).forEach(filePath -> {
+			// Check that the "file" is actually a file and not a directory
+			if(Files.isRegularFile(filePath)) {
+				// Read the data from the file
+				byte[] data = {};
+				try {
+					data = Files.readAllBytes(filePath);
+				} catch(IOException e) {
+					// Having lambdas throw exceptions is complicated so I get around that with this workaround
+					fail(e.getMessage());
+				}
+				String script = new String(data, StandardCharsets.UTF_8);
+
+				// Set up the Lua environment and run the script
+				Player player = new Player();
+				PlayerLuaLibrary.setTarget(player);
+				Globals globals = JsePlatform.standardGlobals();
+				LuaValue chunk = globals.load(script);
+				chunk.call();
+			}
+		});
+	}
+
+}


### PR DESCRIPTION
We have the player class now, so I've written all the scripts that only depend on interaction with the player who drew the card. The remaining card scripts require either moving the player to a board space, which requires the board class, or interacting with other players that didn't draw the card, which will require whatever mechanism we decide should manage players (probably also the board class).

I had to augment the player class a bit, but not by much.

I added a class called Resources, which makes it easier to access resources. Right now all it does is take a path inside the resources directory and converts it to a path that points to that resource.

I also added a test case that runs all the scripts in the /resources/scripts directory to make sure they are syntactically sound.